### PR TITLE
add-missing-invalidation-functions

### DIFF
--- a/ql/src/trailofbits/itergator/invalidations/STL.qll
+++ b/ql/src/trailofbits/itergator/invalidations/STL.qll
@@ -31,6 +31,7 @@ class PotentialInvalidationSTL extends PotentialInvalidation {
         or this.hasName("pop_back")
         or this.hasName("resize")
         or this.hasName("shrink_to_fit")
+        or this.hasName("clear")
     }
 
     predicate dequeInvalidation() {
@@ -44,6 +45,8 @@ class PotentialInvalidationSTL extends PotentialInvalidation {
         or this.hasName("emplace_front")
         or this.hasName("emplace_back")
         or this.hasName("resize")
+        or this.hasName("clear")
+        or this.hasName("shrink_to_fit")
     }
 
     predicate setInvalidation() {


### PR DESCRIPTION
Extends the iteragator queries to detect `.clear()` invalidations for `std::vector` and `std::deque` and `.shrink_to_fit()` for `std::deque`.

Just for reference:
* https://en.cppreference.com/w/cpp/container/vector
* https://en.cppreference.com/w/cpp/container/deque
* https://en.cppreference.com/w/cpp/container/deque/shrink_to_fit - "All iterators and references are invalidated. Past-the-end iterator is also invalidated."
* https://en.cppreference.com/w/cpp/container/deque/clear - "Invalidates any references, pointers, or iterators referring to contained elements. Any past-the-end iterators are also invalidated."
* https://en.cppreference.com/w/cpp/container/vector/clear - "Invalidates any references, pointers, or iterators referring to contained elements. Any past-the-end iterators are also invalidated.  "